### PR TITLE
Cert reload

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1731,6 +1731,7 @@
     "k8s.io/apiserver/pkg/authentication/request/bearertoken",
     "k8s.io/apiserver/pkg/authentication/user",
     "k8s.io/apiserver/pkg/server",
+    "k8s.io/apiserver/pkg/server/options",
     "k8s.io/apiserver/pkg/util/flag",
     "k8s.io/apiserver/pkg/util/globalflag",
     "k8s.io/apiserver/plugin/pkg/authenticator/token/oidc",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -61,7 +61,7 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 
 			healthCheck, err := probe.New(strconv.Itoa(readinessProbePort))
 			if err != nil {
-				fmt.Errorf("failed to initialise readiness probe: %s", err)
+				return fmt.Errorf("failed to initialise readiness probe: %s", err)
 			}
 
 			// client rest config

--- a/demo/gencreds.sh
+++ b/demo/gencreds.sh
@@ -17,8 +17,8 @@ fi
 
 mkdir -p $ROOT
 
-CAFILE="${ROOT}/ca.pem"
-CAKEY="${ROOT}/ca-key.pem"
+CAFILE="${ROOT}/ca.crt"
+CAKEY="${ROOT}/ca.key"
 NAME="kube-oidc-proxy"
 
 HOSTNAME=$1
@@ -33,13 +33,13 @@ openssl req -new -x509 -days 365 \
   -key ${CAKEY} \
   -out ${CAFILE}
 
-echo ">> ca.pem ca-key.pem generated"
+echo ">> ca.crt ca.key generated"
 echo ">> generating a keypair for ${NAME}"
 
 openssl genrsa \
-  -out ${ROOT}/${NAME}-key.pem 2048
+  -out ${ROOT}/${NAME}.key 2048
 
-echo ">> keypair generated ${NAME}-key.pem"
+echo ">> keypair generated ${NAME}.key"
 
 cp ${ROOT}/../openssl.cnf ${ROOT}/openssl-${NAME}.cnf
 sed -i -e "s/HOSTNAME/${HOSTNAME}/g" ${ROOT}/openssl-${NAME}.cnf
@@ -54,7 +54,7 @@ echo ">> requesting serving certificate using openssl-${NAME}.cnf"
 
 openssl req -subj "/CN=${HOSTNAME}" -new \
   -batch \
-  -key ${ROOT}/${NAME}-key.pem \
+  -key ${ROOT}/${NAME}.key \
   -out ${ROOT}/${NAME}-req.csr \
   -config ${ROOT}/openssl-${NAME}.cnf
 
@@ -65,9 +65,9 @@ openssl x509 -req -days 365 \
   -CAcreateserial \
   -extensions v3_req \
   -extfile ${ROOT}/openssl-${NAME}.cnf \
-  -out ${ROOT}/${NAME}-cert.pem
+  -out ${ROOT}/${NAME}.crt
 
 rm ${ROOT}/ca.srl ${ROOT}/${NAME}-req.csr ${ROOT}/openssl-${NAME}.cnf
 
 echo "<< self signed certificate and key generated"
-echo "${ROOT}/${NAME}-cert.pem ${ROOT}/${NAME}-key.pem"
+echo "${ROOT}/${NAME}.crt ${ROOT}/${NAME}.key"

--- a/main.go
+++ b/main.go
@@ -6,10 +6,11 @@ import (
 	"os"
 
 	"github.com/jetstack/kube-oidc-proxy/cmd"
+	"github.com/jetstack/kube-oidc-proxy/pkg/utils"
 )
 
 func main() {
-	stopCh := make(chan struct{})
+	stopCh := utils.SignalHandler()
 	cmd := cmd.NewRunCommand(stopCh)
 
 	if err := cmd.Execute(); err != nil {

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -1,0 +1,110 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/jetstack/kube-oidc-proxy/pkg/utils"
+)
+
+func Test_WatchSecretFiles(t *testing.T) {
+	proxyPort, err := utils.FreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pairTmpDir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(pairTmpDir); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	proxyCertPath, proxyKeyPath, err := utils.NewTLSSelfSignedCertKey(pairTmpDir, "")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	cmd := exec.Command("../../kube-oidc-proxy",
+		"--oidc-issuer-url=https://127.0.0.1:1234",
+		"--oidc-client-id=kube-oidc-proy_e2e_client-id",
+		"--oidc-username-claim=e2e-username-claim",
+		"--secret-watch-refresh-period=5",
+
+		"--bind-address=127.0.0.1",
+		fmt.Sprintf("--secure-port=%s", proxyPort),
+		fmt.Sprintf("--tls-cert-file=%s", proxyCertPath),
+		fmt.Sprintf("--tls-private-key-file=%s", proxyKeyPath),
+
+		"--v=10",
+	)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		// process already exited
+		if cmd.ProcessState != nil &&
+			cmd.ProcessState.Exited() {
+			return
+		}
+
+		if cmd.Process == nil {
+			t.Fatalf("failed to kill process, was nil: %v", cmd.Process)
+		}
+
+		if err := cmd.Process.Kill(); err != nil {
+			t.Errorf("failed to kill kube-oidc-proxy process: %s", err)
+		}
+	}()
+
+	time.Sleep(time.Second * 10)
+
+	if err := ioutil.WriteFile(proxyCertPath, []byte("aa"), 0600); err != nil {
+		t.Error(err)
+		return
+	}
+
+	waitCh := make(chan error)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	waitTime := time.Second * 10
+	timer := time.NewTimer(waitTime)
+
+	// wait for process to exit or until timer ticks
+	select {
+	case err := <-waitCh:
+		if err != nil {
+			t.Errorf("error waiting for process to complete: %s",
+				err)
+		}
+
+	case <-timer.C:
+		t.Errorf("process did not exit in expected time frame (%s)",
+			waitTime.String())
+	}
+
+	if cmd.ProcessState == nil {
+		t.Errorf("unexpected process state, got=%v",
+			cmd.ProcessState)
+	} else if !cmd.ProcessState.Exited() {
+		t.Errorf(
+			"expected kube-oidc-proxy to have exited after file change, but it's still running: %s",
+			cmd.ProcessState.String())
+	} else {
+		t.Log("process exited as expected")
+	}
+}

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -3,6 +3,7 @@ package probe
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -16,7 +17,11 @@ func Test_Check(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	p := New(port)
+	p, err := New(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	time.Sleep(time.Second)
 
 	url := fmt.Sprintf("http://0.0.0.0:%s", port)
@@ -53,5 +58,31 @@ func Test_Check(t *testing.T) {
 	if resp.StatusCode != 503 {
 		t.Errorf("expected ready probe to be responding and not ready, exp=%d got=%d",
 			503, resp.StatusCode)
+	}
+}
+
+func Test_New(t *testing.T) {
+	port, err := utils.FreePort()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ln, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New(port); err == nil {
+		t.Errorf("expected error port taken, got=%s", err)
+	} else {
+		t.Logf("got expected port taken error: %s", err)
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New(port); err != nil {
+		t.Errorf("unexpected error: %s", err)
 	}
 }

--- a/pkg/utils/signals.go
+++ b/pkg/utils/signals.go
@@ -12,7 +12,8 @@ import (
 func SignalHandler() chan struct{} {
 	stopCh := make(chan struct{})
 	ch := make(chan os.Signal, 2)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(ch,
+		syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	go func() {
 		sig := <-ch

--- a/pkg/utils/signals.go
+++ b/pkg/utils/signals.go
@@ -1,0 +1,33 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package utils
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/klog"
+)
+
+func SignalHandler() chan struct{} {
+	stopCh := make(chan struct{})
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-ch
+
+		close(stopCh)
+
+		for i := 0; i < 3; i++ {
+			klog.V(0).Infof("received signal %s, shutting down gracefully...", sig)
+			sig = <-ch
+		}
+
+		klog.V(0).Infof("received signal %s, force closing", sig)
+
+		os.Exit(1)
+	}()
+
+	return stopCh
+}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,0 +1,23 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package utils
+
+import (
+	"sort"
+)
+
+func StringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sort.Strings(a)
+	sort.Strings(b)
+
+	for i, aa := range a {
+		if aa != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/utils/watch.go
+++ b/pkg/utils/watch.go
@@ -1,0 +1,148 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+type fileWatched struct {
+	name    string
+	modTime time.Time
+}
+
+func WatchSecretFiles(restConfig *rest.Config,
+	oidcCAFile *string, kubeconfig *string,
+	ssoptions *apiserveroptions.SecureServingOptions,
+	refreshTimer time.Duration) error {
+
+	files := filesToWatchFromOptions(
+		restConfig, oidcCAFile, kubeconfig, ssoptions)
+
+	if err := watchFiles(refreshTimer, files); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func filesToWatchFromOptions(restConfig *rest.Config,
+	oidcCAFile *string, kubeconfig *string,
+	ssoptions *apiserveroptions.SecureServingOptions,
+) []string {
+	var watchFiles []string
+
+	if len(restConfig.BearerTokenFile) > 0 {
+		watchFiles = append(watchFiles, restConfig.BearerTokenFile)
+	}
+	if len(restConfig.CAFile) > 0 {
+		watchFiles = append(watchFiles, restConfig.CAFile)
+	}
+	if len(restConfig.CertFile) > 0 {
+		watchFiles = append(watchFiles, restConfig.CertFile)
+	}
+	if len(restConfig.KeyFile) > 0 {
+		watchFiles = append(watchFiles, restConfig.KeyFile)
+	}
+
+	if kubeconfig != nil {
+		watchFiles = append(watchFiles, *kubeconfig)
+	}
+
+	if oidcCAFile != nil {
+		watchFiles = append(watchFiles, *oidcCAFile)
+	}
+
+	for _, sni := range ssoptions.SNICertKeys {
+		watchFiles = append(watchFiles, sni.KeyFile)
+
+		watchFiles = append(watchFiles, sni.CertFile)
+	}
+
+	// watch cert directory if key and cert file not explicitly given
+	if len(ssoptions.ServerCert.CertKey.CertFile) == 0 &&
+		len(ssoptions.ServerCert.CertKey.KeyFile) == 0 &&
+		len(ssoptions.ServerCert.CertDirectory) > 0 {
+
+		watchFiles = append(watchFiles,
+			filepath.Join(ssoptions.ServerCert.CertDirectory,
+				ssoptions.ServerCert.PairName+".crt"))
+
+		watchFiles = append(watchFiles,
+			filepath.Join(ssoptions.ServerCert.CertDirectory,
+				ssoptions.ServerCert.PairName+".key"))
+
+	} else {
+
+		if len(ssoptions.ServerCert.CertKey.CertFile) > 0 {
+			watchFiles = append(watchFiles,
+				ssoptions.ServerCert.CertKey.CertFile)
+		}
+		if len(ssoptions.ServerCert.CertKey.KeyFile) > 0 {
+			watchFiles = append(watchFiles,
+				ssoptions.ServerCert.CertKey.KeyFile)
+		}
+	}
+
+	return watchFiles
+}
+
+func watchFiles(refreshTimer time.Duration, files []string) error {
+
+	// initialise file modtimes
+	var watched []fileWatched
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to get file info of %s to watch: %s", f, err)
+		}
+
+		watched = append(watched,
+			fileWatched{f, info.ModTime()})
+	}
+
+	// loop, waiting for change in a file
+	// send SIGHUP to self once one has been detected
+	go func() {
+		for {
+			time.Sleep(refreshTimer)
+
+			for _, f := range watched {
+				info, err := os.Stat(f.name)
+				if err != nil {
+					klog.Errorf("failed to get file stat %s: %s",
+						f.name, err)
+					continue
+				}
+
+				if info.ModTime().After(f.modTime) {
+					klog.Infof("detected change in file %s, exiting", f.name)
+
+					p, err := os.FindProcess(os.Getpid())
+					if err != nil {
+						klog.Errorf("failed to get current pid: %s", err)
+						continue
+					}
+
+					if err := p.Signal(syscall.SIGHUP); err != nil {
+						klog.Errorf("failed to signal current process: %s", err)
+						continue
+					}
+
+					// SIGHUP successful, exit routine
+					return
+				}
+			}
+		}
+	}()
+
+	return nil
+}

--- a/pkg/utils/watch.go
+++ b/pkg/utils/watch.go
@@ -30,6 +30,8 @@ func WatchSecretFiles(restConfig *rest.Config,
 		return err
 	}
 
+	klog.Infof("watching for changes in files %s", files)
+
 	return nil
 }
 
@@ -52,18 +54,22 @@ func filesToWatchFromOptions(restConfig *rest.Config,
 		watchFiles = append(watchFiles, restConfig.KeyFile)
 	}
 
-	if kubeconfig != nil {
+	if kubeconfig != nil && len(*kubeconfig) > 0 {
 		watchFiles = append(watchFiles, *kubeconfig)
 	}
 
-	if oidcCAFile != nil {
+	if oidcCAFile != nil && len(*oidcCAFile) > 0 {
 		watchFiles = append(watchFiles, *oidcCAFile)
 	}
 
 	for _, sni := range ssoptions.SNICertKeys {
-		watchFiles = append(watchFiles, sni.KeyFile)
+		if len(sni.KeyFile) > 0 {
+			watchFiles = append(watchFiles, sni.KeyFile)
+		}
 
-		watchFiles = append(watchFiles, sni.CertFile)
+		if len(sni.CertFile) > 0 {
+			watchFiles = append(watchFiles, sni.CertFile)
+		}
 	}
 
 	// watch cert directory if key and cert file not explicitly given

--- a/pkg/utils/watch.go
+++ b/pkg/utils/watch.go
@@ -129,15 +129,18 @@ func watchFiles(refreshTimer time.Duration, files []string) error {
 					continue
 				}
 
+				// file has been updated
 				if info.ModTime().After(f.modTime) {
 					klog.Infof("detected change in file %s, exiting", f.name)
 
+					// find self process
 					p, err := os.FindProcess(os.Getpid())
 					if err != nil {
 						klog.Errorf("failed to get current pid: %s", err)
 						continue
 					}
 
+					// send SIGHUP to self
 					if err := p.Signal(syscall.SIGHUP); err != nil {
 						klog.Errorf("failed to signal current process: %s", err)
 						continue

--- a/pkg/utils/watch_test.go
+++ b/pkg/utils/watch_test.go
@@ -1,0 +1,277 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/rest"
+)
+
+func Test_fileToWatchFromOptions(t *testing.T) {
+	files, deferFunc, err := testFiles(t, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deferFunc()
+
+	retFiles := filesToWatchFromOptions(
+		&rest.Config{
+			BearerTokenFile: files[0],
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile:   files[1],
+				CertFile: files[2],
+				KeyFile:  files[3],
+			},
+		},
+
+		&files[4],
+		&files[5],
+
+		&apiserveroptions.SecureServingOptions{
+			ServerCert: apiserveroptions.GeneratableKeyCert{
+				CertDirectory: "",
+				PairName:      "pair-name",
+				CertKey: apiserveroptions.CertKey{
+					CertFile: files[6],
+					KeyFile:  files[7],
+				},
+			},
+		},
+	)
+
+	if !StringsEqual(files, retFiles) {
+		t.Errorf("unexpected files to watch, exp=%s got=%s",
+			files, retFiles)
+	}
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cert-pairs")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// create paired key-cert
+	f, err := os.Create(filepath.Join(tmpDir, "pair-name.key"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	pairKey := f.Name()
+
+	f, err = os.Create(filepath.Join(tmpDir, "pair-name.crt"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	pairCert := f.Name()
+
+	// should still use overridden provided key pair
+	retFiles = filesToWatchFromOptions(
+		&rest.Config{
+			BearerTokenFile: files[0],
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile:   files[1],
+				CertFile: files[2],
+				KeyFile:  files[3],
+			},
+		},
+
+		&files[4],
+		&files[5],
+
+		&apiserveroptions.SecureServingOptions{
+			ServerCert: apiserveroptions.GeneratableKeyCert{
+				CertDirectory: tmpDir,
+				PairName:      "pair-name",
+				CertKey: apiserveroptions.CertKey{
+					CertFile: files[6],
+					KeyFile:  files[7],
+				},
+			},
+		},
+	)
+
+	if !StringsEqual(files, retFiles) {
+		t.Errorf("unexpected files to watch, exp=%s got=%s",
+			files, retFiles)
+	}
+
+	// should not use certs in dir
+	retFiles = filesToWatchFromOptions(
+		&rest.Config{
+			BearerTokenFile: files[0],
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile:   files[1],
+				CertFile: files[2],
+				KeyFile:  files[3],
+			},
+		},
+
+		&files[4],
+		&files[5],
+
+		&apiserveroptions.SecureServingOptions{
+			ServerCert: apiserveroptions.GeneratableKeyCert{
+				CertDirectory: tmpDir,
+				PairName:      "pair-name",
+				CertKey: apiserveroptions.CertKey{
+					CertFile: files[6],
+				},
+			},
+		},
+	)
+
+	if !StringsEqual(append(files[:7]), retFiles) {
+		t.Errorf("unexpected files to watch, exp=%s got=%s",
+			files, retFiles)
+	}
+
+	// should not use certs in dir
+	retFiles = filesToWatchFromOptions(
+		&rest.Config{
+			BearerTokenFile: files[0],
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile:   files[1],
+				CertFile: files[2],
+				KeyFile:  files[3],
+			},
+		},
+
+		&files[4],
+		&files[5],
+
+		&apiserveroptions.SecureServingOptions{
+			ServerCert: apiserveroptions.GeneratableKeyCert{
+				CertDirectory: tmpDir,
+				PairName:      "pair-name",
+				CertKey: apiserveroptions.CertKey{
+					KeyFile: files[6],
+				},
+			},
+		},
+	)
+
+	if !StringsEqual(append(files[:7]), retFiles) {
+		t.Errorf("unexpected files to watch, exp=%s got=%s",
+			files, retFiles)
+	}
+
+	// should use certs in dir
+	retFiles = filesToWatchFromOptions(
+		&rest.Config{
+			BearerTokenFile: files[0],
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile:   files[1],
+				CertFile: files[2],
+				KeyFile:  files[3],
+			},
+		},
+
+		&files[4],
+		&files[5],
+
+		&apiserveroptions.SecureServingOptions{
+			ServerCert: apiserveroptions.GeneratableKeyCert{
+				CertDirectory: tmpDir,
+				PairName:      "pair-name",
+			},
+		},
+	)
+
+	if !StringsEqual(append(files[:6], pairKey, pairCert), retFiles) {
+		t.Errorf("unexpected files to watch, exp=%s got=%s",
+			files, retFiles)
+	}
+}
+
+func Test_watchFiles(t *testing.T) {
+	files, deferFunc, err := testFiles(t, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deferFunc()
+
+	ch := make(chan os.Signal, 4)
+	signal.Notify(ch, syscall.SIGHUP)
+
+	for _, f := range files {
+		watchFiles(time.Second/2, files)
+		testWatchFileChange(t, f, ch)
+	}
+}
+
+func testFiles(t *testing.T, count int) ([]string, func(), error) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "WatchSecretFiles")
+	if err != nil {
+		return nil, nil, err
+	}
+	deferFunc := func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("failed to remove temp directory: %s",
+				err)
+		}
+	}
+
+	files := make([]string, count)
+	for i := range files {
+		f, err := ioutil.TempFile(tmpDir, "")
+		if err != nil {
+			deferFunc()
+			return nil, nil, err
+		}
+
+		files[i] = f.Name()
+	}
+
+	return files, deferFunc, nil
+}
+
+func testWatchFileChange(t *testing.T, f string, ch chan os.Signal) {
+	ticker := time.NewTicker(time.Second)
+
+	// no change
+	select {
+	case <-ch:
+		t.Errorf(
+			"expected no HUP signal after not changing file %s", f)
+	case <-ticker.C:
+		break
+	}
+
+	// change
+	err := ioutil.WriteFile(f, []byte("a"), 0644)
+	if err != nil {
+		t.Errorf("failed to write to watch file: %s", err)
+		return
+	}
+
+	select {
+	case <-ch:
+		break
+	case <-ticker.C:
+		t.Errorf(
+			"expected HUP signal after changing file %s", f)
+	}
+
+	// change again
+	err = ioutil.WriteFile(f, []byte("b"), 0644)
+	if err != nil {
+		t.Errorf("failed to write to watch file: %s", err)
+		return
+	}
+
+	select {
+	case <-ch:
+		t.Errorf(
+			"expected no HUP signal after changing file twice %s", f)
+	case <-ticker.C:
+		break
+	}
+}

--- a/pkg/utils/watch_test.go
+++ b/pkg/utils/watch_test.go
@@ -219,9 +219,12 @@ func Test_watchFiles(t *testing.T) {
 	signal.Notify(ch, syscall.SIGHUP)
 
 	for _, f := range files {
-		watchFiles(time.Second/2,
+		err := watchFiles(time.Second/2,
 			// mix of actual paths and symbolic links
 			[]string{files[0], syms[0], syms[1], files[3]})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		expectWatchFileChange(t, f, ch)
 	}


### PR DESCRIPTION
Adds watchers to client and serving files. If the files change, send SIGHUP to self to exit gracefully.
Check every minute.
Can be disabled or changed with CLI flag.
Adds flag for changing readiness probe port. Useful for testing.
End to end tests for watcher and proxy exiting gracefully.
Readiness probe checks if port is in use before returning + tests.

Rebased on top of #15 

fixes #16 

/assign @simonswine 