### PR TITLE
Add Kubernetes v1.14 to e2e tests and use as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,16 +100,19 @@ generate: depend ## generates mocks and assets files
 test: generate verify ## run all go tests
 	go test $$(go list ./pkg/... ./cmd/... | grep -v cmd/e2e)
 
-e2e: e2e-1.13 ## run end to end tests
+e2e: e2e-1.14 ## run end to end tests
+
+e2e-1.14: build ## run end to end tests for kubernetes version 1.14
+	KUBE_OIDC_PROXY_NODE_IMAGE=v1.14.0 go test ./cmd/e2e/. -v --count=1
 
 e2e-1.13: build ## run end to end tests for kubernetes version 1.13
-	KUBE_OIDC_PROXY_NODE_IMAGE=v1.13.3 go test ./cmd/e2e/. -v
+	KUBE_OIDC_PROXY_NODE_IMAGE=v1.13.3 go test ./cmd/e2e/. -v --count=1
 
 e2e-1.12: build ## run end to end tests for kubernetes version 1.12
-	KUBE_OIDC_PROXY_NODE_IMAGE=v1.12.5 go test ./cmd/e2e/. -v
+	KUBE_OIDC_PROXY_NODE_IMAGE=v1.12.5 go test ./cmd/e2e/. -v --count=1
 
 e2e-1.11: build ## run end to end tests for kubernetes version 1.11
-	KUBE_OIDC_PROXY_NODE_IMAGE=v1.11.3 go test ./cmd/e2e/. -v
+	KUBE_OIDC_PROXY_NODE_IMAGE=v1.11.3 go test ./cmd/e2e/. -v --count=1
 
 build: generate ## build kube-oidc-proxy
 	CGO_ENABLED=0 go build

--- a/cmd/e2e/e2e_test.go
+++ b/cmd/e2e/e2e_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultNodeImage = "v1.13.3"
+	defaultNodeImage = "v1.14.0"
 )
 
 func Test_E2E(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

/assign @simonswine 

Also added --count=1 to disable using cached testing when using different Kubernetes versions