### PR TITLE
Add support for dex connectors

### DIFF
--- a/demo/config.dist.jsonnet
+++ b/demo/config.dist.jsonnet
@@ -7,5 +7,15 @@
     users: [
       $.dex.Password('admin@example.net', '$2y$10$i2.tSLkchjnpvnI73iSW/OPAVriV9BWbdfM6qemBM1buNRu81.ZG.'),  // plaintext: secure
     ],
+    // This shows how to add dex connectors
+    connectors: [
+      $.dex.Connector('github', 'GitHub', 'github', {
+        clientID: '0123',
+        clientSecret: '4567',
+        orgs: [{
+          name: 'example-net',
+        }],
+      }),
+    ],
   },
 }

--- a/demo/manifests/components/dex.jsonnet
+++ b/demo/manifests/components/dex.jsonnet
@@ -61,6 +61,19 @@ local dexNameHash(s) = std.asciiLower(std.strReplace(base32.base32(fakeHashFNV(s
     id: name,
   },
 
+  // Create a connector configuration for dex
+  Connector(id, name, type, config):: kube._Object(dexAPIGroup + '/' + dexAPIVersion, 'Connector', id) + {
+    metadata+: {
+      namespace: $.namespace,
+    },
+    id: id,
+    name: name,
+    type: type,
+    config: std.base64(std.manifestJsonEx({
+      redirectURI: 'https://' + $.domain + '/callback',
+    } + config, '  ')),
+  },
+
   p:: '',
 
   namespace:: 'auth',


### PR DESCRIPTION
This allows configuring e.g. GitHub auth in dex.

There is an example in the dist (which I have renamed to end in `.jsonnet`)

```release-note
Add support for dex connectors
```

/assign @JoshVanL 