### PR TITLE
Use the groups claim by default in Kube-OIDC-Proxy

### DIFF
--- a/demo/manifests/components/kube-oidc-proxy.jsonnet
+++ b/demo/manifests/components/kube-oidc-proxy.jsonnet
@@ -40,6 +40,8 @@ local READINESS_PORT = 8080;
       clientID: 'kube-oidc-proxy',
       usernameClaim: 'email',
       issuerURL: 'https://myprovider',
+      groupsClaim: 'groups',
+      groupsPrefix: 'dex:',
     },
   },
 
@@ -107,6 +109,8 @@ local READINESS_PORT = 8080;
                 '--secure-port=' + $.config.secureServing.port,
                 '--tls-cert-file=' + $.config.secureServing.tlsCertFile,
                 '--tls-private-key-file=' + $.config.secureServing.tlsKeyFile,
+                '--oidc-groups-prefix=' + $.config.oidc.groupsPrefix,
+                '--oidc-groups-claim=' + $.config.oidc.groupsClaim,
                 '--oidc-client-id=$(OIDC_CLIENT_ID)',
                 '--oidc-issuer-url=$(OIDC_ISSUER_URL)',
               ] + if std.objectHas($.config.oidc, 'caFile') then


### PR DESCRIPTION
Signed-off-by: Christian Simon <simon@swine.de>

```release-notes
Add groups claims to Kube-OIDC-Proxy
```