### PR TITLE
Use jetstack quay.io image location for kube-oidc-proxy

### DIFF
--- a/demo/manifests/components/kube-oidc-proxy.jsonnet
+++ b/demo/manifests/components/kube-oidc-proxy.jsonnet
@@ -108,6 +108,7 @@ local READINESS_PORT = 8080;
                 periodSeconds: 10,
               },
               command: [
+                'kube-oidc-proxy',
                 '--secure-port=' + $.config.secureServing.port,
                 '--tls-cert-file=' + $.config.secureServing.tlsCertFile,
                 '--tls-private-key-file=' + $.config.secureServing.tlsKeyFile,

--- a/demo/yaml/kube-oidc-proxy.yaml
+++ b/demo/yaml/kube-oidc-proxy.yaml
@@ -28,7 +28,7 @@ spec:
         app: kube-oidc-proxy
     spec:
       containers:
-      - image: quay.io/jetstack/kube-oidc-proxy
+      - image: quay.io/jetstack/kube-oidc-proxy:0.1.0
         ports:
         - containerPort: 443
         - containerPort: 8080
@@ -38,6 +38,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         name: kube-oidc-proxy
+        command: ["kube-oidc-proxy"]
         args:
           - "--secure-port=443"
           - "--tls-cert-file=/etc/oidc/tls/crt.pem"


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

/assign @simonswine 