### PR TITLE
Register all known client auth plugins

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1961,6 +1961,7 @@
     "k8s.io/cli-runtime/pkg/genericclioptions",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/plugin/pkg/client/auth/oidc",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,8 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package cmd
+
+import (
+	// This package is required to be imported to register all client
+	// plugins.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

```release-note
Ensure all client plugins are vendored an registered for proxy auth to the API server.
```