### PR TITLE
Initialize OIDC provider before reporting proxy as ready

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,11 +2,11 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
@@ -23,6 +23,7 @@ import (
 	"github.com/jetstack/kube-oidc-proxy/pkg/probe"
 	"github.com/jetstack/kube-oidc-proxy/pkg/proxy"
 	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/tokenreview"
+	"github.com/jetstack/kube-oidc-proxy/pkg/util"
 	"github.com/jetstack/kube-oidc-proxy/pkg/version"
 )
 
@@ -121,7 +122,12 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 				return err
 			}
 
-			time.Sleep(time.Second * 3)
+			// try initializing provider
+			ctx := context.Background()
+			err = util.InitProvider(ctx, oidcOptions, stopCh)
+			if err != nil {
+				return err
+			}
 			healthCheck.SetReady()
 
 			<-waitCh

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -124,7 +124,7 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 
 			// try initializing provider
 			ctx := context.Background()
-			err = util.InitProvider(ctx, oidcOptions, stopCh)
+			err = util.InitProviderUntil(ctx, oidcOptions, stopCh)
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/Masterminds/semver v1.4.2
+	github.com/coreos/go-oidc v0.0.0-20180117170138-065b426bd416
 	github.com/golang/mock v0.0.0-20160127222235-bd3c8e81be01
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
 	github.com/sirupsen/logrus v1.4.2

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -30,6 +30,10 @@ import (
 	"github.com/jetstack/kube-oidc-proxy/pkg/util"
 )
 
+const (
+	readinessProbeURL = "http://127.0.0.1:8080/ready"
+)
+
 type E2E struct {
 	kubeclient     *kubernetes.Clientset
 	kubeKubeconfig string
@@ -198,7 +202,10 @@ func (e *E2E) newIssuerProxyPair() (*http.Transport, error) {
 
 	e.proxyCmd = cmd
 
-	time.Sleep(time.Second * 13)
+	_, err = verifyProxyReadinessPoll(readinessProbeURL, 2*time.Second, 30*time.Second)
+	if err != nil {
+		return nil, err
+	}
 
 	return transport, nil
 }
@@ -306,8 +313,10 @@ func (e *E2E) runProxy(extraArgs ...string) error {
 
 	e.proxyCmd = cmd
 
-	// wait more than enough for proxy to become ready
-	time.Sleep(time.Second * 13)
+	_, err := verifyProxyReadinessPoll(readinessProbeURL, 2*time.Second, 30*time.Second)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -87,10 +87,6 @@ func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	proxyHandler.Transport = p
 	proxyHandler.ErrorHandler = p.Error
 
-	// wait for oidc auther to become ready
-	klog.Infof("waiting for oidc provider to become ready...")
-	time.Sleep(10 * time.Second)
-
 	waitCh, err := p.serve(proxyHandler, stopCh)
 	if err != nil {
 		return nil, err

--- a/pkg/util/provider.go
+++ b/pkg/util/provider.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	oidc "github.com/coreos/go-oidc"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/jetstack/kube-oidc-proxy/cmd/options"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+func InitProvider(ctx context.Context, opts *options.OIDCAuthenticationOptions, stopCh <-chan struct{}) error {
+	url, err := url.Parse(opts.IssuerURL)
+	if err != nil {
+		return err
+	}
+
+	if url.Scheme != "https" {
+		return fmt.Errorf("'oidc-issuer-url' (%q) has invalid scheme (%q), require 'https'", opts.IssuerURL, url.Scheme)
+	}
+
+	var roots *x509.CertPool
+	if opts.CAFile != "" {
+		roots, err = certutil.NewPool(opts.CAFile)
+		if err != nil {
+			return fmt.Errorf("Failed to read the CA file: %v", err)
+		}
+	} else {
+		klog.Info("OIDC: No x509 certificates provided, will use host's root CA set")
+	}
+
+	// Copied from http.DefaultTransport.
+	tr := netutil.SetTransportDefaults(&http.Transport{
+		// According to golang's doc, if RootCAs is nil,
+		// TLS uses the host's root CA set.
+		TLSClientConfig: &tls.Config{RootCAs: roots},
+	})
+
+	client := &http.Client{Transport: tr, Timeout: 30 * time.Second}
+
+	ctx = oidc.ClientContext(ctx, client)
+	return wait.PollUntil(time.Second*10, func() (bool, error) {
+		_, err := oidc.NewProvider(ctx, opts.IssuerURL)
+		if err != nil {
+			klog.Errorf("failed to initialize oidc provider: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}, stopCh)
+}

--- a/pkg/util/provider.go
+++ b/pkg/util/provider.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package util
 
 import (
@@ -11,11 +12,11 @@ import (
 
 	oidc "github.com/coreos/go-oidc"
 	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog"
 
 	"github.com/jetstack/kube-oidc-proxy/cmd/options"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
 )
 
 func InitProvider(ctx context.Context, opts *options.OIDCAuthenticationOptions, stopCh <-chan struct{}) error {
@@ -32,10 +33,10 @@ func InitProvider(ctx context.Context, opts *options.OIDCAuthenticationOptions, 
 	if opts.CAFile != "" {
 		roots, err = certutil.NewPool(opts.CAFile)
 		if err != nil {
-			return fmt.Errorf("Failed to read the CA file: %v", err)
+			return fmt.Errorf("failed to read the CA file: %v", err)
 		}
 	} else {
-		klog.Info("OIDC: No x509 certificates provided, will use host's root CA set")
+		klog.Info("oidc: no x509 certificates provided, will use host's root CA set")
 	}
 
 	// Copied from http.DefaultTransport.

--- a/pkg/util/provider.go
+++ b/pkg/util/provider.go
@@ -19,7 +19,9 @@ import (
 	"github.com/jetstack/kube-oidc-proxy/cmd/options"
 )
 
-func InitProvider(ctx context.Context, opts *options.OIDCAuthenticationOptions, stopCh <-chan struct{}) error {
+// InitProviderUntil tries to initialize the OIDC Provider described by the
+// options. It tries until stopCh is closed.
+func InitProviderUntil(ctx context.Context, opts *options.OIDCAuthenticationOptions, stopCh <-chan struct{}) error {
 	url, err := url.Parse(opts.IssuerURL)
 	if err != nil {
 		return err


### PR DESCRIPTION
An alternative to #93. Fixes #92.

Upside: Does not fork `k8s.io/apiserver`
Downsides:
- Duplicates, by necessity, a lot of the initialization code in `k8s.io/apiserver/plugin/pkg/authenticator/token/oidc`.
- Successful provider initialization does not guarantee that the OIDC authenticator itself has successfully initialized.

/cc @JoshVanL 