### PR TITLE
Readiness check through blackbox usage

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server"
@@ -98,16 +97,13 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 
 			p := proxy.New(restConfig, oidcOptions,
-				tokenReviewer, secureServingInfo, proxyOptions)
+				tokenReviewer, secureServingInfo, healthCheck, proxyOptions)
 
 			// run proxy
 			waitCh, err := p.Run(stopCh)
 			if err != nil {
 				return err
 			}
-
-			time.Sleep(time.Second * 3)
-			healthCheck.SetReady()
 
 			<-waitCh
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/jetstack/kube-oidc-proxy/cmd/options"
+	"github.com/jetstack/kube-oidc-proxy/pkg/probe"
 	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/tokenreview"
 )
 
@@ -50,17 +51,19 @@ type Proxy struct {
 	restConfig            *rest.Config
 	clientTransport       http.RoundTripper
 	noAuthClientTransport http.RoundTripper
+	healthCheck           *probe.HealthCheck
 
 	options *Options
 }
 
 func New(restConfig *rest.Config, oidcOptions *options.OIDCAuthenticationOptions,
-	tokenReviewer *tokenreview.TokenReview, ssinfo *server.SecureServingInfo, options *Options) *Proxy {
+	tokenReviewer *tokenreview.TokenReview, ssinfo *server.SecureServingInfo, healthCheck *probe.HealthCheck, options *Options) *Proxy {
 	return &Proxy{
 		restConfig:        restConfig,
 		oidcOptions:       oidcOptions,
 		tokenReviewer:     tokenReviewer,
 		secureServingInfo: ssinfo,
+		healthCheck:       healthCheck,
 		options:           options,
 	}
 }
@@ -143,6 +146,7 @@ func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, error) {
 				continue
 			}
 
+			p.healthCheck.SetReady()
 			klog.Info("OIDC provider initialized, proxy ready")
 			klog.V(4).Infof("OIDC provider initialized, readiness check returned error: %+v", err)
 			return


### PR DESCRIPTION
* This seems to be a cleaner approach than #92 #93

I just ran out of time implementing this properly as we need a dynamic oidc token to get past the early checks in here:

https://github.com/kubernetes/apiserver/blob/ab2ea16b1965071ce4a3cea61f11397e0e5b5fcf/plugin/pkg/authenticator/token/oidc/oidc.go#L556

/cc @JoshVanL 
/assign