### PR TITLE
Add Service annotations to Helm Charts

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/service.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -16,6 +16,10 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 443
+  annotations:
+    # You can use this field to add annotations to the Service.
+    # Define it in a key-value pairs. E.g.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: true
 
 tls:
   # `secretName` must be a name of Secret of TLS type. If not provided a


### PR DESCRIPTION
This PR enables the ability to add Service annotations via Helm Charts.

Signed-off-by: Yudi A Phanama <yudiandreanp@gmail.com>