### PR TITLE
Makes readiness probe rely on proxy initialization on issuer

### DIFF
--- a/cmd/app/options/kube_oidc_proxy.go
+++ b/cmd/app/options/kube_oidc_proxy.go
@@ -13,6 +13,8 @@ type TokenPassthroughOptions struct {
 type KubeOIDCProxyOptions struct {
 	DisableImpersonation bool
 	TokenPassthrough     TokenPassthroughOptions
+
+	ReadinessProbePort int
 }
 
 func (t *TokenPassthroughOptions) AddFlags(fs *pflag.FlagSet) {
@@ -33,6 +35,9 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&k.DisableImpersonation, "disable-impersonation", k.DisableImpersonation,
 		"(Alpha) Disable the impersonation of authenticated requests. All "+
 			"authenticated requests will be forwarded as is.")
+
+	fs.IntVarP(&k.ReadinessProbePort, "readiness-probe-port", "P", 8080,
+		"Port to expose readiness probe.")
 
 	k.TokenPassthrough.AddFlags(fs)
 }

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/server"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/util/term"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
@@ -86,23 +86,6 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 				}
 			}
 
-			// oidc config
-			oidcAuther, err := oidc.New(oidc.Options{
-				APIAudiences:         oidcOptions.APIAudiences,
-				CAFile:               oidcOptions.CAFile,
-				ClientID:             oidcOptions.ClientID,
-				GroupsClaim:          oidcOptions.GroupsClaim,
-				GroupsPrefix:         oidcOptions.GroupsPrefix,
-				IssuerURL:            oidcOptions.IssuerURL,
-				RequiredClaims:       oidcOptions.RequiredClaims,
-				SupportedSigningAlgs: oidcOptions.SigningAlgs,
-				UsernameClaim:        oidcOptions.UsernameClaim,
-				UsernamePrefix:       oidcOptions.UsernamePrefix,
-			})
-			if err != nil {
-				return err
-			}
-
 			// Init token reviewer if enabled
 			var tokenReviewer *tokenreview.TokenReview
 			if kopOptions.TokenPassthrough.Enabled {
@@ -113,7 +96,6 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 
 			// oidc auther from config
-			reqAuther := bearertoken.New(oidcAuther)
 			secureServingInfo := new(server.SecureServingInfo)
 			if err := ssoptionsWithLB.ApplyTo(&secureServingInfo, nil); err != nil {
 				return err
@@ -124,7 +106,7 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 				DisableImpersonation: kopOptions.DisableImpersonation,
 			}
 
-			p := proxy.New(restConfig, reqAuther,
+			p := proxy.New(restConfig, oidcOptions,
 				tokenReviewer, secureServingInfo, proxyOptions)
 
 			// run proxy

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	readinessProbePort = 8080
+	appName = "kube-oidc-proxy"
 )
 
 func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
@@ -36,7 +36,7 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 		BindPort:    6443,
 		Required:    true,
 		ServerCert: apiserveroptions.GeneratableKeyCert{
-			PairName:      "kube-oidc-proxy",
+			PairName:      appName,
 			CertDirectory: "/var/run/kubernetes",
 		},
 	}
@@ -48,7 +48,7 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 
 	// proxy command
 	cmd := &cobra.Command{
-		Use:  "kube-oidc-proxy",
+		Use:  appName,
 		Long: "kube-oidc-proxy is a reverse proxy to authenticate users to Kubernetes API servers with Open ID Connect Authentication.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
@@ -61,7 +61,7 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 				return err
 			}
 
-			if ssoptionsWithLB.SecureServingOptions.BindPort == readinessProbePort {
+			if ssoptionsWithLB.SecureServingOptions.BindPort == kopOptions.ReadinessProbePort {
 				return errors.New("unable to securely serve on port 8080, used by readiness prob")
 			}
 
@@ -116,8 +116,8 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 
 			// Start readiness probe
-			if err := probe.Run(strconv.Itoa(readinessProbePort),
-				fakeJWT, p.OIDCAuthenticator()); err != nil {
+			if err := probe.Run(strconv.Itoa(kopOptions.ReadinessProbePort),
+				fakeJWT, p.OIDCTokenAuthenticator()); err != nil {
 				return err
 			}
 

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server"
@@ -107,16 +106,13 @@ func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 
 			p := proxy.New(restConfig, oidcOptions,
-				tokenReviewer, secureServingInfo, proxyOptions)
+				tokenReviewer, secureServingInfo, healthCheck, proxyOptions)
 
 			// run proxy
 			waitCh, err := p.Run(stopCh)
 			if err != nil {
 				return err
 			}
-
-			time.Sleep(time.Second * 3)
-			healthCheck.SetReady()
 
 			<-waitCh
 

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/heptiolabs/healthcheck"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	//"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/klog"
 )
 

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 
@@ -50,14 +49,22 @@ func TestRun(t *testing.T) {
 		t.FailNow()
 	}
 
-	// Wait for probe to become ready
-	time.Sleep(time.Second)
-
 	url := fmt.Sprintf("http://0.0.0.0:%s", port)
 
-	resp, err := http.Get(url + "/ready")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	var resp *http.Response
+	var i int
+
+	for {
+		resp, err = http.Get(url + "/ready")
+		if err == nil {
+			break
+		}
+
+		if i >= 5 {
+			t.Errorf("unexpected error: %s", err)
+			t.FailNow()
+		}
+		i++
 	}
 
 	if resp.StatusCode != 503 {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -10,14 +10,18 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	authuser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/klog"
 
+	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
 	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/tokenreview"
 )
 
@@ -39,6 +43,7 @@ type Options struct {
 
 type Proxy struct {
 	oidcAuther        *bearertoken.Authenticator
+	oidcOptions       *options.OIDCAuthenticationOptions
 	tokenReviewer     *tokenreview.TokenReview
 	secureServingInfo *server.SecureServingInfo
 
@@ -49,11 +54,11 @@ type Proxy struct {
 	options *Options
 }
 
-func New(restConfig *rest.Config, oidcAuther *bearertoken.Authenticator,
+func New(restConfig *rest.Config, oidcOptions *options.OIDCAuthenticationOptions,
 	tokenReviewer *tokenreview.TokenReview, ssinfo *server.SecureServingInfo, options *Options) *Proxy {
 	return &Proxy{
 		restConfig:        restConfig,
-		oidcAuther:        oidcAuther,
+		oidcOptions:       oidcOptions,
 		tokenReviewer:     tokenReviewer,
 		secureServingInfo: ssinfo,
 		options:           options,
@@ -61,7 +66,23 @@ func New(restConfig *rest.Config, oidcAuther *bearertoken.Authenticator,
 }
 
 func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, error) {
-	klog.Infof("waiting for oidc provider to become ready...")
+	// generate oidcAuther from oidc config
+	oidcAuther, err := oidc.New(oidc.Options{
+		APIAudiences:         p.oidcOptions.APIAudiences,
+		CAFile:               p.oidcOptions.CAFile,
+		ClientID:             p.oidcOptions.ClientID,
+		GroupsClaim:          p.oidcOptions.GroupsClaim,
+		GroupsPrefix:         p.oidcOptions.GroupsPrefix,
+		IssuerURL:            p.oidcOptions.IssuerURL,
+		RequiredClaims:       p.oidcOptions.RequiredClaims,
+		SupportedSigningAlgs: p.oidcOptions.SigningAlgs,
+		UsernameClaim:        p.oidcOptions.UsernameClaim,
+		UsernamePrefix:       p.oidcOptions.UsernamePrefix,
+	})
+	if err != nil {
+		return nil, err
+	}
+	p.oidcAuther = bearertoken.New(oidcAuther)
 
 	// standard round tripper for proxy to API Server
 	clientRT, err := p.roundTripperForRestConfig(p.restConfig)
@@ -99,16 +120,40 @@ func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	proxyHandler.Transport = p
 	proxyHandler.ErrorHandler = p.Error
 
-	// wait for oidc auther to become ready
-	klog.Infof("waiting for oidc provider to become ready...")
-	time.Sleep(10 * time.Second)
+	// probe for readiness
+	go func() {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		for {
+			<-ticker.C
+			fr, err := http.NewRequest("GET", "http://fake", nil)
+			if err != nil {
+				klog.Infof("error during readiness check: %v", err)
+				continue
+			}
+			jwt, err := p.fakeJWT()
+			if err != nil {
+				klog.Infof("error during readiness check: %v", err)
+				continue
+			}
+			fr.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwt))
+
+			_, _, err = p.oidcAuther.AuthenticateRequest(fr)
+			if strings.HasSuffix(err.Error(), "authenticator not initialized") {
+				klog.V(4).Infof("OIDC provider not yet initialized")
+				continue
+			}
+
+			klog.Info("OIDC provider initialized, proxy ready")
+			klog.V(4).Infof("OIDC provider initialized, readiness check returned error: %+v", err)
+			return
+		}
+
+	}()
 
 	waitCh, err := p.serve(proxyHandler, stopCh)
 	if err != nil {
 		return nil, err
 	}
-
-	klog.Infof("proxy ready")
 
 	return waitCh, nil
 }
@@ -191,6 +236,24 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// push request through round trippers to the API server
 	return rt.RoundTrip(reqCpy)
+}
+
+// fakeJWT generates a JWT that passes the first offline validity checks. It is
+// used to test if the OIDC provider is initialised
+func (p *Proxy) fakeJWT() (string, error) {
+	key := []byte("secret")
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		return "", err
+	}
+
+	cl := jwt.Claims{
+		Subject:   "readiness",
+		Issuer:    p.oidcOptions.IssuerURL,
+		NotBefore: jwt.NewNumericDate(time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Audience:  jwt.Audience(p.oidcOptions.APIAudiences),
+	}
+	return jwt.Signed(sig).Claims(cl).CompactSerialize()
 }
 
 func (p *Proxy) tokenReview(req *http.Request) (*http.Response, error) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -257,9 +257,9 @@ func newTestProxy(t *testing.T) *fakeProxy {
 		fakeToken: fakeToken,
 		fakeRT:    fakeRT,
 		Proxy: &Proxy{
-			oidcAuther:      bearertoken.New(fakeToken),
-			clientTransport: fakeRT,
-			options:         new(Options),
+			oidcRequestAuther: bearertoken.New(fakeToken),
+			clientTransport:   fakeRT,
+			options:           new(Options),
 		},
 	}
 }

--- a/pkg/util/token.go
+++ b/pkg/util/token.go
@@ -4,6 +4,10 @@ package util
 import (
 	"net/http"
 	"strings"
+	"time"
+
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // Return just the token from the header of the request, without 'bearer'.
@@ -30,4 +34,27 @@ func ParseTokenFromRequest(req *http.Request) (string, bool) {
 	}
 
 	return token, true
+}
+
+// fakeJWT generates a valid JWT using the passed input parameters which is
+// signed by a generated key. This is useful for checking the status of a
+// signer.
+func FakeJWT(issuerURL string, apiAudiences []string) (string, error) {
+	key := []byte("secret")
+
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		return "", err
+	}
+
+	cl := jwt.Claims{
+		Subject:   "fake",
+		Issuer:    issuerURL,
+		NotBefore: jwt.NewNumericDate(time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Audience:  jwt.Audience(apiAudiences),
+	}
+
+	return jwt.Signed(sig).Claims(cl).CompactSerialize()
 }

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -67,7 +67,7 @@ func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL, clientID string,
 					Port: intstr.FromInt(8080),
 				},
 			},
-			InitialDelaySeconds: 9,
+			InitialDelaySeconds: 1,
 			PeriodSeconds:       3,
 		},
 	}

--- a/test/e2e/suite/cases/doc.go
+++ b/test/e2e/suite/cases/doc.go
@@ -4,6 +4,7 @@ package cases
 import (
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/impersonation"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/passthrough"
+	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/probe"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/rbac"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/token"
 	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/upgrade"

--- a/test/e2e/suite/cases/probe/probe.go
+++ b/test/e2e/suite/cases/probe/probe.go
@@ -1,0 +1,40 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package probe
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework/helper"
+)
+
+var _ = framework.CasesDescribe("Readiness Probe", func() {
+	f := framework.NewDefaultFramework("readiness-probe")
+
+	It("Should not become ready if the issuer is unavailable", func() {
+		By("Deleting the Issuer so no longer becomes reachable")
+		Expect(f.Helper().DeleteIssuer(f.Namespace.Name)).NotTo(HaveOccurred())
+
+		By("Deleting the current proxy that is ready")
+		Expect(f.Helper().DeleteProxy(f.Namespace.Name)).NotTo(HaveOccurred())
+
+		By("Deploying the Proxy should never become ready as the issuer is unavailable")
+		_, _, err := f.Helper().DeployProxy(f.Namespace, f.IssuerURL(),
+			f.ClientID(), f.IssuerKeyBundle())
+		// Error should occur (not ready)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should continue to be ready even if the issuer becomes unavailable", func() {
+		By("Deleting the Issuer so no longer becomes reachable")
+		Expect(f.Helper().DeleteIssuer(f.Namespace.Name)).NotTo(HaveOccurred())
+
+		time.Sleep(time.Second * 10)
+
+		err := f.Helper().WaitForPodReady(f.Namespace.Name, helper.ProxyName, time.Second*5)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Sets proxy readiness probe to be based on the initialization of it's discovery of the OIDC issuer.

```release-notes
Improves readiness probe to be based on whether the proxy has successfully made a discovery on the OIDC issuer
````
/assign
/milestone v0.2
fixes #92 