### PR TITLE
Add Pod Disruption Budget to Helm Charts

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kube-oidc-proxy.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+{{ include "kube-oidc-proxy.labels" . | indent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kube-oidc-proxy.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -68,6 +68,11 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Enable Pod Disruption Budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR adds capability to use Pod Disruption Budget to the Helm Charts.

Signed-off-by: Yudi A Phanama <yudiandreanp@gmail.com>