### PR TITLE
Handler based chaining for proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ go_vet:
 	go vet ./cmd
 
 go_lint: $(BINDIR)/golangci-lint ## lint golang code for problems
-	$(BINDIR)/golangci-lint run
+	$(BINDIR)/golangci-lint run --timeout 3m
 
 clean: ## clean up created files
 	rm -rf \

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -80,6 +80,11 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 		errs = append(errs, errors.New("unable to securely serve on port 8080 (used by readiness probe)"))
 	}
 
+	if o.App.DisableImpersonation &&
+		(o.App.ExtraHeaderOptions.EnableClientIPExtraUserHeader || len(o.App.ExtraHeaderOptions.ExtraUserHeaders) > 0) {
+		errs = append(errs, errors.New("cannot add extra user headers when impersonation disabled"))
+	}
+
 	if len(errs) > 0 {
 		return k8sErrors.NewAggregate(errs)
 	}

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -72,7 +72,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				return err
 			}
 
-			proxyOptions := &proxy.Options{
+			proxyConfig := &proxy.Config{
 				TokenReview:          opts.App.TokenPassthrough.Enabled,
 				DisableImpersonation: opts.App.DisableImpersonation,
 
@@ -84,7 +84,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 			// Initialise proxy with OIDC token authenticator
 			p, err := proxy.New(restConfig, opts.OIDCAuthentication,
-				tokenReviewer, secureServingInfo, proxyOptions)
+				tokenReviewer, secureServingInfo, proxyConfig)
 			if err != nil {
 				return err
 			}

--- a/pkg/proxy/context/context.go
+++ b/pkg/proxy/context/context.go
@@ -1,0 +1,56 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package context
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/transport"
+)
+
+type key int
+
+const (
+	// noImpersonationKey is the context key for whether to use impersonation.
+	noImpersonationKey key = iota
+
+	// impersonationConfigKey is the context key for the impersonation config.
+	impersonationConfigKey
+
+	// bearerTokenKey is the context key for the bearer token.
+	bearerTokenKey
+)
+
+// WithNoImpersonation returns a copy of parent in which the noImpersonation value is set.
+func WithNoImpersonation(parent context.Context) context.Context {
+	return request.WithValue(parent, noImpersonationKey, true)
+}
+
+// NoImpersonation returns whether the noImpersonation key has been set
+func NoImpersonation(ctx context.Context) bool {
+	noImp, _ := ctx.Value(noImpersonationKey).(bool)
+	return noImp
+}
+
+// WithImpersonationConfig returns a copy of parent in which contains the impersonation configuration.
+func WithImpersonationConfig(parent context.Context, conf *transport.ImpersonationConfig) context.Context {
+	return request.WithValue(parent, impersonationConfigKey, conf)
+}
+
+// ImpersonationConfig returns the impersonation configuration held in the context if existing.
+func ImpersonationConfig(ctx context.Context) *transport.ImpersonationConfig {
+	conf, _ := ctx.Value(impersonationConfigKey).(*transport.ImpersonationConfig)
+	return conf
+}
+
+// WithBearerToken will add the bearer token from an http.Header to the context.
+func WithBearerToken(parent context.Context, header http.Header) context.Context {
+	return request.WithValue(parent, bearerTokenKey, header.Get("Authorization"))
+}
+
+// BearerToken will return the bearer token stored in the context.
+func BearerToken(ctx context.Context) string {
+	token, _ := ctx.Value(bearerTokenKey).(string)
+	return token
+}

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -1,0 +1,208 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package proxy
+
+import (
+	"net/http"
+	"strings"
+
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/transport"
+	"k8s.io/klog"
+
+	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/context"
+)
+
+func (p *Proxy) withHandlers(handler http.Handler) http.Handler {
+	// Set up proxy handlers
+	handler = p.withImpersonateRequest(handler)
+	handler = p.withAuthenticateRequest(handler)
+	return handler
+}
+
+// withAuthenticateRequest adds the proxy authentication handler to a chain.
+func (p *Proxy) withAuthenticateRequest(handler http.Handler) http.Handler {
+	tokenReviewHandler := p.withTokenReview(handler)
+
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Auth request and handle unauthed
+		info, ok, err := p.oidcRequestAuther.AuthenticateRequest(req)
+		if err != nil {
+			// Since we have failed OIDC auth, we will try a token review, if enabled.
+			tokenReviewHandler.ServeHTTP(rw, req)
+			return
+		}
+
+		// Failed authorization
+		if !ok {
+			p.handleError(rw, req, errUnauthorized)
+			return
+		}
+
+		klog.V(4).Infof("authenticated request: %s", req.RemoteAddr)
+
+		// Add the user info to the request context
+		req = req.WithContext(genericapirequest.WithUser(req.Context(), info.User))
+		handler.ServeHTTP(rw, req)
+	})
+}
+
+// withTokenReview will attempt a token review on the incoming request, if
+// enabled.
+func (p *Proxy) withTokenReview(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// If token review is not enabled then error.
+		if !p.config.TokenReview {
+			p.handleError(rw, req, errUnauthorized)
+			return
+		}
+
+		// Attempt to passthrough request if valid token
+		if !p.reviewToken(rw, req) {
+			// Token review failed so error
+			p.handleError(rw, req, errUnauthorized)
+			return
+		}
+
+		// Set no impersonation headers and re-add removed headers.
+		req = req.WithContext(context.WithNoImpersonation(req.Context()))
+
+		handler.ServeHTTP(rw, req)
+	})
+}
+
+// withImpersonateRequest adds the impersonation request handler to the chain.
+func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// If no impersonation has already been set, return early
+		if context.NoImpersonation(req.Context()) {
+			handler.ServeHTTP(rw, req)
+			return
+		}
+
+		// If we have disabled impersonation we can forward the request right away
+		if p.config.DisableImpersonation {
+			klog.V(2).Infof("passing on request with no impersonation: %s", req.RemoteAddr)
+			// Indicate we need to not use impersonation.
+			req = req.WithContext(context.WithNoImpersonation(req.Context()))
+			handler.ServeHTTP(rw, req)
+			return
+		}
+
+		if p.hasImpersonation(req.Header) {
+			p.handleError(rw, req, errImpersonateHeader)
+			return
+		}
+
+		user, ok := genericapirequest.UserFrom(req.Context())
+		// No name available so reject request
+		if !ok || len(user.GetName()) == 0 {
+			p.handleError(rw, req, errNoName)
+			return
+		}
+
+		// Ensure group contains allauthenticated builtin
+		allAuthFound := false
+		groups := user.GetGroups()
+		for _, elem := range groups {
+			if elem == authuser.AllAuthenticated {
+				allAuthFound = true
+				break
+			}
+		}
+		if !allAuthFound {
+			groups = append(groups, authuser.AllAuthenticated)
+		}
+
+		extra := user.GetExtra()
+
+		if extra == nil {
+			extra = make(map[string][]string)
+		}
+
+		// If client IP user extra header option set then append the remote client
+		// address.
+		if p.config.ExtraUserHeadersClientIPEnabled {
+			klog.V(6).Infof("adding impersonate extra user header %s: %s (%s)",
+				UserHeaderClientIPKey, req.RemoteAddr, req.RemoteAddr)
+
+			extra[UserHeaderClientIPKey] = append(extra[UserHeaderClientIPKey], req.RemoteAddr)
+		}
+
+		// Add custom extra user headers to impersonation request.
+		for k, vs := range p.config.ExtraUserHeaders {
+			for _, v := range vs {
+				klog.V(6).Infof("adding impersonate extra user header %s: %s (%s)",
+					k, v, req.RemoteAddr)
+
+				extra[k] = append(extra[k], v)
+			}
+		}
+
+		conf := &transport.ImpersonationConfig{
+			UserName: user.GetName(),
+			Groups:   groups,
+			Extra:    extra,
+		}
+
+		// Add the impersonation configuration to the context.
+		req = req.WithContext(context.WithImpersonationConfig(req.Context(), conf))
+		handler.ServeHTTP(rw, req)
+	})
+}
+
+// newErrorHandler returns a handler failed requests.
+func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, err error) {
+	return func(rw http.ResponseWriter, r *http.Request, err error) {
+		if err == nil {
+			klog.Error("error was called with no error")
+			http.Error(rw, "", http.StatusInternalServerError)
+			return
+		}
+
+		switch err {
+
+		// Failed auth
+		case errUnauthorized:
+			klog.V(2).Infof("unauthenticated user request %s", r.RemoteAddr)
+			http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+			return
+
+			// User request with impersonation
+		case errImpersonateHeader:
+			klog.V(2).Infof("impersonation user request %s", r.RemoteAddr)
+			http.Error(rw, "Impersonation requests are disabled when using kube-oidc-proxy", http.StatusForbidden)
+			return
+
+			// No name given or available in oidc request
+		case errNoName:
+			klog.V(2).Infof("no name available in oidc info %s", r.RemoteAddr)
+			http.Error(rw, "Username claim not available in OIDC Issuer response", http.StatusForbidden)
+			return
+
+			// No impersonation configuration found in context
+		case errNoImpersonationConfig:
+			klog.Errorf("if you are seeing this, there is likely a bug in the proxy (%s): %s", r.RemoteAddr, err)
+			http.Error(rw, "", http.StatusInternalServerError)
+			return
+
+			// Server or unknown error
+		default:
+			klog.Errorf("unknown error (%s): %s", r.RemoteAddr, err)
+			http.Error(rw, "", http.StatusInternalServerError)
+		}
+	}
+}
+
+func (p *Proxy) hasImpersonation(header http.Header) bool {
+	for h := range header {
+		if strings.ToLower(h) == impersonateUserHeader ||
+			strings.ToLower(h) == impersonateGroupHeader ||
+			strings.HasPrefix(strings.ToLower(h), impersonateExtraHeader) {
+
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,8 +12,6 @@ import (
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
-	authuser "k8s.io/apiserver/pkg/authentication/user"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/client-go/rest"
@@ -160,13 +158,6 @@ func (p *Proxy) serve(handler http.Handler, stopCh <-chan struct{}) (<-chan stru
 	return waitCh, nil
 }
 
-func (p *Proxy) withHandlers(handler http.Handler) http.Handler {
-	// Set up proxy handlers
-	handler = p.withImpersonateRequest(handler)
-	handler = p.withAuthenticateRequest(handler)
-	return handler
-}
-
 // RoundTrip is called last and is used to manipulate the forwarded request using context.
 func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Here we have successfully authenticated so now need to determine whether
@@ -192,138 +183,6 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Push request through round trippers to the API server.
 	return rt.RoundTrip(req)
 }
-
-// withAuthenticateRequest adds the proxy authentication handler to a chain.
-func (p *Proxy) withAuthenticateRequest(handler http.Handler) http.Handler {
-	tokenReviewHandler := p.withTokenReview(handler)
-
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Auth request and handle unauthed
-		info, ok, err := p.oidcRequestAuther.AuthenticateRequest(req)
-		if err != nil {
-			// Since we have failed OIDC auth, we will try a token review, if enabled.
-			tokenReviewHandler.ServeHTTP(rw, req)
-			return
-		}
-
-		// Failed authorization
-		if !ok {
-			p.handleError(rw, req, errUnauthorized)
-			return
-		}
-
-		klog.V(4).Infof("authenticated request: %s", req.RemoteAddr)
-
-		// Add the user info to the request context
-		req = req.WithContext(genericapirequest.WithUser(req.Context(), info.User))
-		handler.ServeHTTP(rw, req)
-	})
-}
-
-// withTokenReview will attempt a token review on the incoming request, if
-// enabled.
-func (p *Proxy) withTokenReview(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// If token review is not enabled then error.
-		if !p.config.TokenReview {
-			p.handleError(rw, req, errUnauthorized)
-			return
-		}
-
-		// Attempt to passthrough request if valid token
-		if !p.reviewToken(rw, req) {
-			// Token review failed so error
-			p.handleError(rw, req, errUnauthorized)
-			return
-		}
-
-		// Set no impersonation headers and re-add removed headers.
-		req = req.WithContext(context.WithNoImpersonation(req.Context()))
-
-		handler.ServeHTTP(rw, req)
-	})
-}
-
-// withImpersonateRequest adds the impersonation request handler to the chain.
-func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// If no impersonation has already been set, return early
-		if context.NoImpersonation(req.Context()) {
-			handler.ServeHTTP(rw, req)
-			return
-		}
-
-		// If we have disabled impersonation we can forward the request right away
-		if p.config.DisableImpersonation {
-			klog.V(2).Infof("passing on request with no impersonation: %s", req.RemoteAddr)
-			// Indicate we need to not use impersonation.
-			req = req.WithContext(context.WithNoImpersonation(req.Context()))
-			handler.ServeHTTP(rw, req)
-			return
-		}
-
-		if p.hasImpersonation(req.Header) {
-			p.handleError(rw, req, errImpersonateHeader)
-			return
-		}
-
-		user, ok := genericapirequest.UserFrom(req.Context())
-		// No name available so reject request
-		if !ok || len(user.GetName()) == 0 {
-			p.handleError(rw, req, errNoName)
-			return
-		}
-
-		// Ensure group contains allauthenticated builtin
-		allAuthFound := false
-		groups := user.GetGroups()
-		for _, elem := range groups {
-			if elem == authuser.AllAuthenticated {
-				allAuthFound = true
-				break
-			}
-		}
-		if !allAuthFound {
-			groups = append(groups, authuser.AllAuthenticated)
-		}
-
-		extra := user.GetExtra()
-
-		if extra == nil {
-			extra = make(map[string][]string)
-		}
-
-		// If client IP user extra header option set then append the remote client
-		// address.
-		if p.config.ExtraUserHeadersClientIPEnabled {
-			klog.V(6).Infof("adding impersonate extra user header %s: %s (%s)",
-				UserHeaderClientIPKey, req.RemoteAddr, req.RemoteAddr)
-
-			extra[UserHeaderClientIPKey] = append(extra[UserHeaderClientIPKey], req.RemoteAddr)
-		}
-
-		// Add custom extra user headers to impersonation request.
-		for k, vs := range p.config.ExtraUserHeaders {
-			for _, v := range vs {
-				klog.V(6).Infof("adding impersonate extra user header %s: %s (%s)",
-					k, v, req.RemoteAddr)
-
-				extra[k] = append(extra[k], v)
-			}
-		}
-
-		conf := &transport.ImpersonationConfig{
-			UserName: user.GetName(),
-			Groups:   groups,
-			Extra:    extra,
-		}
-
-		// Add the impersonation configuration to the context.
-		req = req.WithContext(context.WithImpersonationConfig(req.Context(), conf))
-		handler.ServeHTTP(rw, req)
-	})
-}
-
 func (p *Proxy) reviewToken(rw http.ResponseWriter, req *http.Request) bool {
 	klog.V(4).Infof("attempting to validate a token in request using TokenReview endpoint(%s)",
 		req.RemoteAddr)
@@ -344,62 +203,6 @@ func (p *Proxy) reviewToken(rw http.ResponseWriter, req *http.Request) bool {
 
 	// No error and ok so passthrough the request
 	return true
-}
-
-func (p *Proxy) hasImpersonation(header http.Header) bool {
-	for h := range header {
-		if strings.ToLower(h) == impersonateUserHeader ||
-			strings.ToLower(h) == impersonateGroupHeader ||
-			strings.HasPrefix(strings.ToLower(h), impersonateExtraHeader) {
-
-			return true
-		}
-	}
-
-	return false
-}
-
-// newErrorHandler returns a handler failed requests.
-func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, err error) {
-	return func(rw http.ResponseWriter, r *http.Request, err error) {
-		if err == nil {
-			klog.Error("error was called with no error")
-			http.Error(rw, "", http.StatusInternalServerError)
-			return
-		}
-
-		switch err {
-
-		// Failed auth
-		case errUnauthorized:
-			klog.V(2).Infof("unauthenticated user request %s", r.RemoteAddr)
-			http.Error(rw, "Unauthorized", http.StatusUnauthorized)
-			return
-
-			// User request with impersonation
-		case errImpersonateHeader:
-			klog.V(2).Infof("impersonation user request %s", r.RemoteAddr)
-			http.Error(rw, "Impersonation requests are disabled when using kube-oidc-proxy", http.StatusForbidden)
-			return
-
-			// No name given or available in oidc request
-		case errNoName:
-			klog.V(2).Infof("no name available in oidc info %s", r.RemoteAddr)
-			http.Error(rw, "Username claim not available in OIDC Issuer response", http.StatusForbidden)
-			return
-
-			// No impersonation configuration found in context
-		case errNoImpersonationConfig:
-			klog.Errorf("if you are seeing this, there is likely a bug in the proxy (%s): %s", r.RemoteAddr, err)
-			http.Error(rw, "", http.StatusInternalServerError)
-			return
-
-			// Server or unknown error
-		default:
-			klog.Errorf("unknown error (%s): %s", r.RemoteAddr, err)
-			http.Error(rw, "", http.StatusInternalServerError)
-		}
-	}
 }
 
 func (p *Proxy) roundTripperForRestConfig(config *rest.Config) (http.RoundTripper, error) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -91,8 +91,14 @@ func (f *Framework) BeforeEach() {
 
 // AfterEach deletes the namespace, after reading its events.
 func (f *Framework) AfterEach() {
+	// Output logs from proxy of test case.
+	err := f.Helper().Kubectl(f.Namespace.Name).Run("logs", "-lapp=kube-oidc-proxy-e2e")
+	if err != nil {
+		By("Failed to gather logs from kube-oidc-proxy: " + err.Error())
+	}
+
 	By("Deleting kube-oidc-proxy deployment")
-	err := f.Helper().DeleteProxy(f.Namespace.Name)
+	err = f.Helper().DeleteProxy(f.Namespace.Name)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Deleting mock OIDC issuer")


### PR DESCRIPTION
Currently, the proxy holds all of the business logic in the RoundTrip func. This has become quite unwieldy, and difficult to test. This PR moves each stage of the proxy into http.Handler which makes things a bit more cleaner and idiomatic. This is also a prerequisite for the audit work.

This PR makes use of context in the request to hold state of user information, impersonate etc.

This PR is branched out of #133  and should be merged first.

/assign @simonswine 
/hold