### PR TITLE
Adds --flush-interval to set the flush interval of proxy handler

### DIFF
--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -2,6 +2,8 @@
 package options
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
 
@@ -11,6 +13,8 @@ import (
 type KubeOIDCProxyOptions struct {
 	DisableImpersonation bool
 	ReadinessProbePort   int
+
+	FlushInterval time.Duration
 
 	ExtraHeaderOptions ExtraHeaderOptions
 	TokenPassthrough   TokenPassthroughOptions
@@ -38,6 +42,12 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions
 
 	fs.IntVarP(&k.ReadinessProbePort, "readiness-probe-port", "P", 8080,
 		"Port to expose readiness probe.")
+
+	fs.DurationVar(&k.FlushInterval, "flush-interval", time.Millisecond*50,
+		"Specifies the interval to flush request bodies. If 0ms, "+
+			"no periodic flushing is done. A negative value means to flush "+
+			"immediately after each write. Ignored, and flushed immediately, when "+
+			"responses are recognised as streaming (i.e. kubectl exec).")
 
 	k.TokenPassthrough.AddFlags(fs)
 	k.ExtraHeaderOptions.AddFlags(fs)

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -46,8 +46,8 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions
 	fs.DurationVar(&k.FlushInterval, "flush-interval", time.Millisecond*50,
 		"Specifies the interval to flush request bodies. If 0ms, "+
 			"no periodic flushing is done. A negative value means to flush "+
-			"immediately after each write. Ignored, and flushed immediately, when "+
-			"responses are recognised as streaming (i.e. kubectl exec).")
+			"immediately after each write. Streaming requests such as 'kubectl exec' "+
+			"will ignore this option and flush immediately.")
 
 	k.TokenPassthrough.AddFlags(fs)
 	k.ExtraHeaderOptions.AddFlags(fs)

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -76,6 +76,8 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				TokenReview:          opts.App.TokenPassthrough.Enabled,
 				DisableImpersonation: opts.App.DisableImpersonation,
 
+				FlushInterval: opts.App.FlushInterval,
+
 				ExtraUserHeaders:                opts.App.ExtraHeaderOptions.ExtraUserHeaders,
 				ExtraUserHeadersClientIPEnabled: opts.App.ExtraHeaderOptions.EnableClientIPExtraUserHeader,
 			}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -43,6 +43,8 @@ type Options struct {
 	DisableImpersonation bool
 	TokenReview          bool
 
+	FlushInterval time.Duration
+
 	ExtraUserHeaders                map[string][]string
 	ExtraUserHeadersClientIPEnabled bool
 }
@@ -127,6 +129,7 @@ func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	proxyHandler := httputil.NewSingleHostReverseProxy(url)
 	proxyHandler.Transport = p
 	proxyHandler.ErrorHandler = p.Error
+	proxyHandler.FlushInterval = p.options.FlushInterval
 
 	waitCh, err := p.serve(proxyHandler, stopCh)
 	if err != nil {


### PR DESCRIPTION
This PR adds the flag `--flush-interval`. This sets the proxy handler to flush request bodies at the given duration. The default is 50ms. If zero, no flushing is done. If negative, it will flush immediately. The proxy handler will ignore the value is a streaming request is recognized and will flush immediately.

/assign @simonswine 
fixes #135  