### PR TITLE
Enable HTTP_PROXY and HTTPS_PROXY environment variables

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -237,6 +237,7 @@ func (p *Proxy) roundTripperForRestConfig(config *rest.Config) (http.RoundTrippe
 
 	// create tls transport to request
 	tlsTransport := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

/assign @munnerz 
fixes #153 

```release-note
Enable use of HTTP_PROXY and HTTPS_PROXY environment variables for the proxy
```