### PR TITLE
Change probe readiness log output to be less confusing for happy path

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -66,8 +66,8 @@ func (h *HealthCheck) Check() error {
 
 	h.ready = true
 
+	klog.V(4).Infof("OIDC provider initialized, readiness check returned expected error: %s", err)
 	klog.Info("OIDC provider initialized, proxy ready")
-	klog.V(4).Infof("OIDC provider initialized, readiness check returned error: %s", err)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

This PR changes the probe log output to be in a more logical order and is more clear that this is a happy error.

/assign @simonswine 