### PR TITLE
chore: do not missing fields to secret

### DIFF
--- a/deploy/charts/kube-oidc-proxy/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.0
+version: 0.3.1
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
@@ -1,29 +1,43 @@
 apiVersion: v1
-data:
-  {{ if .Values.oidc.caPEM }}
-  oidc.ca-pem: {{ .Values.oidc.caPEM | default "" | b64enc }}
-  {{ end }}
-  oidc.issuer-url: {{ .Values.oidc.issuerUrl | b64enc }}
-  oidc.username-claim: {{ .Values.oidc.usernameClaim | b64enc }}
-  oidc.client-id: {{ .Values.oidc.clientId | b64enc }}
-  {{- if .Values.oidc.usernamePrefix }}
-  oidc.username-prefix: {{ .Values.oidc.usernamePrefix | b64enc }}
-  {{- end }}
-  {{- if .Values.oidc.groupsClaim }}
-  oidc.groups-claim: {{ .Values.oidc.groupsClaim | b64enc }}
-  {{- end }}
-  {{- if .Values.oidc.groupsPrefix }}
-  oidc.groups-prefix: {{ .Values.oidc.groupsPrefix | b64enc }}
-  {{- end }}
-  {{- if .Values.oidc.signingAlgs }}
-  oidc.signing-algs: {{ join "," .Values.oidc.signingAlgs | b64enc }}
-  {{- end }}
-  {{ if .Values.oidc.requiredClaims }}
-  oidc.required-claims: {{ include "requiredClaims" . | b64enc }}
-  {{- end }}
 kind: Secret
 metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}-config
   labels:
-{{ include "kube-oidc-proxy.labels" . | indent 4 }}
+  {{ include "kube-oidc-proxy.labels" . | indent 4 }}
 type: Opaque
+data:
+  {{- if .Values.oidc.caPEM }}
+  oidc.ca-pem: {{ .Values.oidc.caPEM | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.issuerUrl }}
+  oidc.issuer-url: {{ .Values.oidc.issuerUrl | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.usernameClaim }}
+  oidc.username-claim: {{ .Values.oidc.usernameClaim | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.clientId }}
+  oidc.client-id: {{ .Values.oidc.clientId | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.usernamePrefix }}
+  oidc.username-prefix: {{ .Values.oidc.usernamePrefix | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.groupsClaim }}
+  oidc.groups-claim: {{ .Values.oidc.groupsClaim | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.groupsPrefix }}
+  oidc.groups-prefix: {{ .Values.oidc.groupsPrefix | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.signingAlgs }}
+  oidc.signing-algs: {{ join "," .Values.oidc.signingAlgs | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.requiredClaims }}
+  oidc.required-claims: {{ include "requiredClaims" . | b64enc }}
+  {{- end }}


### PR DESCRIPTION
Here secret-config is updated to not write out fields with empty (nil) values. We also format for readability. 