### PR TITLE
fix_secret_config

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}-config
   labels:
-  {{ include "kube-oidc-proxy.labels" . | indent 4 }}
+{{ include "kube-oidc-proxy.labels" . | indent 4 }}
 type: Opaque
 data:
   {{- if .Values.oidc.caPEM }}


### PR DESCRIPTION
fix error when do the helm install.

YAML parse error on kube-oidc-proxy/templates/secret_config.yaml: error converting YAML to JSON: yaml: line 6: did not find expected key

Signed-off-by: Allan Hung <hung.allan@gmail.com>