### PR TITLE
Update alpine to resolve CVE-2020-1967

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
-FROM alpine:3.10
+FROM alpine:3.12.1
 LABEL description="OIDC reverse proxy authenticator based on Kubernetes"
 
 RUN apk --no-cache add ca-certificates \


### PR DESCRIPTION
This PR is to update alpine to the latest version `alpine:3.12.1` this will resolve CVE-2020-1967

Signed-off-by: Kieran Robinson <krobn@allstate.com>