### PR TITLE
ISSUE-180 Updating CluserRole to include userextras/remote-client-ip

### DIFF
--- a/deploy/charts/kube-oidc-proxy/templates/clusterrole.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
   - "authentication.k8s.io"
   resources:
   - "userextras/scopes"
+  - "userextras/remote-client-ip"
   - "tokenreviews"
   verbs:
   - "create"

--- a/deploy/yaml/kube-oidc-proxy.yaml
+++ b/deploy/yaml/kube-oidc-proxy.yaml
@@ -135,6 +135,7 @@ rules:
   - "authentication.k8s.io"
   resources:
   - "userextras/scopes"
+  - "userextras/remote-client-ip"
   - "tokenreviews"
   verbs:
   - "create"


### PR DESCRIPTION
Updating `ClusterRole` in `helm` chart and deployment manifests to include `userextras/remote-client-ip` which is required for `--extra-user-header-client-ip`.

This pull request is to address ISSUE-180 (https://github.com/jetstack/kube-oidc-proxy/issues/180)