### PR TITLE
OIDC auth request failure

### DIFF
--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -34,6 +34,7 @@ func (p *Proxy) withAuthenticateRequest(handler http.Handler) http.Handler {
 		// Auth request and handle unauthed
 		info, ok, err := p.oidcRequestAuther.AuthenticateRequest(req)
 		if err != nil {
+			klog.V(6).Infof("OIDC authenticate request failed due to: %q", err)
 			// Since we have failed OIDC auth, we will try a token review, if enabled.
 			tokenReviewHandler.ServeHTTP(rw, req)
 			return


### PR DESCRIPTION
I'm not sure whether it's actually ok to do so from a security perspective.

Not knowing why the initial OIDC auth call failed costs a lot of time though. This should be doable debug log mode maybe? 