### PR TITLE
Helm service additional spec

### DIFF
--- a/deploy/charts/kube-oidc-proxy/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: mhrabovcin
 - name: joshvanl

--- a/deploy/charts/kube-oidc-proxy/templates/service.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/service.yaml
@@ -25,3 +25,6 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "kube-oidc-proxy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.service.additionalSpec }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -16,13 +16,18 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 443
-  annotations:
+  annotations: {}
     # You can use this field to add annotations to the Service.
     # Define it in a key-value pairs. E.g.
     # service.beta.kubernetes.io/aws-load-balancer-internal: true
 
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
+
+  additionalSpec: {}
+    # You can use this field to add additional spec parametes to the Service.
+    # Define it in a key-value pairs. E.g.
+    # externalTrafficPolicy: Local
 
 tls:
   # `secretName` must be a name of Secret of TLS type. If not provided a


### PR DESCRIPTION
Add service.additionalSpec options to helm chart. 

**UseCase**:
NodePort with ExternalDNS: 
Only get IP's for k8s nodes running kube-oidc-proxy pods (not all nodes in cluster).
```
service:
  additionalSpec:
    externalTrafficPolicy: Local
```